### PR TITLE
Updates for guide

### DIFF
--- a/recipes/data-management/context-broker/ha/.gitignore
+++ b/recipes/data-management/context-broker/ha/.gitignore
@@ -1,2 +1,0 @@
-mongo-docker-compose.yml
-mongo-healthcheck

--- a/recipes/data-management/context-broker/ha/backend.env
+++ b/recipes/data-management/context-broker/ha/backend.env
@@ -1,6 +1,0 @@
-# Env variables to customize the recipe.
-STACK_NAME="mongo-rs"
-MONGO_SERVICE_URI="mongo-rs_mongo"
-
-MONGO_VERSION=3.2
-REPLICASET_NAME="rs"

--- a/recipes/data-management/context-broker/ha/deploy_back.sh
+++ b/recipes/data-management/context-broker/ha/deploy_back.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -o allexport
-. ./backend.env
-set +o allexport
-curl https://raw.githubusercontent.com/smartsdk/mongo-rs-controller-swarm/master/docker-compose.yml -o mongo-docker-compose.yml
-curl -O https://raw.githubusercontent.com/smartsdk/mongo-rs-controller-swarm/master/mongo-healthcheck
-docker stack deploy -c mongo-docker-compose.yml ${STACK_NAME}

--- a/recipes/data-management/context-broker/ha/deploy_front.sh
+++ b/recipes/data-management/context-broker/ha/deploy_front.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -o allexport
-. ./backend.env
-. ./frontend.env
-set +o allexport
-docker stack deploy -c docker-compose.yml ${STACK_NAME}

--- a/recipes/data-management/context-broker/ha/docker-compose.yml
+++ b/recipes/data-management/context-broker/ha/docker-compose.yml
@@ -3,10 +3,10 @@ version: '3'
 services:
 
   orion:
-    image: fiware/orion:${ORION_VERSION:-1.7.0}
+    image: fiware/orion:${ORION_VERSION:-1.12.0}
     ports:
       - "1026:1026"
-    command: -logLevel DEBUG -dbhost ${MONGO_SERVICE_URI:-"mongo-rs_mongo"} -rplSet ${REPLICASET_NAME:-rs} -dbTimeout 10000
+    command: -logLevel ${ORION_LOG_LEVEL:-DEBUG} -dbhost ${MONGO_SERVICE_URI:-"mongo"} -rplSet ${REPLICASET_NAME:-rs} -dbTimeout 10000
     deploy:
       replicas: 2
     networks:
@@ -19,6 +19,7 @@ services:
       retries: 3
 
 networks:
+  # Legacy for running with docker-compose in FIWARE Lab
   default:
     driver_opts:
       com.docker.network.driver.mtu: ${DOCKER_MTU:-1400}

--- a/recipes/data-management/context-broker/ha/frontend.env
+++ b/recipes/data-management/context-broker/ha/frontend.env
@@ -1,6 +1,0 @@
-# Env variables to customize the recipe.
-STACK_NAME="orion"
-
-ORION_VERSION=1.7.0
-MONGO_SERVICE_URI=${MONGO_SERVICE_URI:-"mongo-rs_mongo"}
-REPLICASET_NAME=${REPLICASET_NAME:-rs}

--- a/recipes/data-management/context-broker/ha/readme.md
+++ b/recipes/data-management/context-broker/ha/readme.md
@@ -73,12 +73,14 @@ The default values should be fine for you if you used the
 [Mongo ReplicaSet Recipe](../../../utils/mongo-replicaset/readme.md).
 
 Now you can activate your settings and deploy Orion...
+
 ```
 $ source settings.env  # In Windows, simply execute settings.bat instead.
 $ docker stack deploy -c docker-compose.yml orion
 ```
 
 At some point, your deployment should look like this...
+
 ```
 $ docker service ls
 ID            NAME                       MODE        REPLICAS  IMAGE

--- a/recipes/data-management/context-broker/ha/readme.md
+++ b/recipes/data-management/context-broker/ha/readme.md
@@ -56,15 +56,15 @@ If you don't have one, checkout the [tools](../../../tools/readme.md) section
 for a quick way to setup a local swarm.
 
 ```
-    $ miniswarm start 3
-    $ eval $(docker-machine env ms-manager0)
+$ miniswarm start 3
+$ eval $(docker-machine env ms-manager0)
 ```
 
 Orion needs a mongo database for its backend. If you have already deployed Mongo
 within your cluster and would like to reuse that database, you can skip the next
 step (deploying backend). You will just need to pay attention to the variables
-you define for Orion to link to Mongo, namely, `MONGO_SERVICE_URI`
-and `REPLICASET_NAME`. Make sure you have the correct values in `frontend.env`.
+you define for Orion to link to Mongo, namely, `MONGO_SERVICE_URI`. Make sure
+you have the correct values in `settings.env` (or `settings.bat` in Windows).
 The value of `MONGO_SERVICE_URI` should be a routable address for mongo.
 If deployed within the swarm, the service name (with stack prefix)
 would suffice. You can read more in the
@@ -72,30 +72,22 @@ would suffice. You can read more in the
 The default values should be fine for you if you used the
 [Mongo ReplicaSet Recipe](../../../utils/mongo-replicaset/readme.md).
 
-Otherwise, if you prefer to make a new deployment of Mongo just for Orion,
-you can take a shortcut and run...
-
+Now you can activate your settings and deploy Orion...
 ```
-    $ sh deploy_back.sh
-```
-
-Wait some time until the backend is ready and then...
-
-```
-    $ sh deploy_front.sh
+$ source settings.env  # In Windows, simply execute settings.bat instead.
+$ docker stack deploy -c docker-compose.yml orion
 ```
 
 At some point, your deployment should look like this...
-
 ```
-    $ docker service ls
-    ID            NAME                            MODE        REPLICAS  IMAGE
-    nrxbm6k0a2yn  mongo-rs_mongo             global      3/3       mongo:3.2
-    rgws8vumqye2  mongo-rs_mongo-controller  replicated  1/1       martel/mongo-replica-ctrl:latest
-    zk7nu592vsde  orion_orion                     replicated  3/3       fiware/orion:1.3.0
+$ docker service ls
+ID            NAME                       MODE        REPLICAS  IMAGE
+nrxbm6k0a2yn  mongo-rs_mongo             global      3/3       mongo:3.2
+rgws8vumqye2  mongo-rs_mongo-controller  replicated  1/1       martel/mongo-replica-ctrl:latest
+zk7nu592vsde  orion_orion                replicated  3/3       fiware/orion:1.3.0
 ```
 
-As shown above, if you see `3/3`in the replicas column it means the 3 replicas
+As shown above, if you see `3/3` in the replicas column it means the 3 replicas
 are up and running.
 
 ## A walkthrough
@@ -104,11 +96,11 @@ You can check the distribution of the containers of a service (a.k.a tasks)
 through the swarm running the following...
 
 ```
-    $ docker service ps orion_orion
-    ID            NAME                    IMAGE               NODE         DESIRED STATE  CURRENT STATE               ERROR  PORTS
-    wwgt3q6nqqg3  orion_orion.1  fiware/orion:1.3.0  ms-worker0   Running        Running 9 minutes ago          
-    l1wavgqra8ry  orion_orion.2  fiware/orion:1.3.0  ms-worker1   Running        Running 9 minutes ago          
-    z20v0pnym8ky  orion_orion.3  fiware/orion:1.3.0  ms-manager0  Running        Running 25 minutes ago    
+$ docker service ps orion_orion
+ID            NAME           IMAGE               NODE         DESIRED STATE  CURRENT STATE               ERROR  PORTS
+wwgt3q6nqqg3  orion_orion.1  fiware/orion:1.3.0  ms-worker0   Running        Running 9 minutes ago          
+l1wavgqra8ry  orion_orion.2  fiware/orion:1.3.0  ms-worker1   Running        Running 9 minutes ago          
+z20v0pnym8ky  orion_orion.3  fiware/orion:1.3.0  ms-manager0  Running        Running 25 minutes ago    
 ```
 
 The good news is that, as you can see from the above output, by default docker
@@ -125,23 +117,23 @@ The question now is... where is Orion actually running? We'll cover the network
 internals later, but for now let's query the manager node...
 
 ```
-    $ sh ../query.sh $(docker-machine ip ms-manager0)
+$ sh ../query.sh $(docker-machine ip ms-manager0)
 ```
 
 You will get something like...
 
 ```
-    {
-      "orion" : {
-      "version" : "1.3.0",
-      "uptime" : "0 d, 0 h, 18 m, 13 s",
-      "git_hash" : "cb6813f044607bc01895296223a27e4466ab0913",
-      "compile_time" : "Fri Sep 2 08:19:12 UTC 2016",
-      "compiled_by" : "root",
-      "compiled_in" : "ba19f7d3be65"
-    }
-    }
-    []
+{
+  "orion" : {
+  "version" : "1.3.0",
+  "uptime" : "0 d, 0 h, 18 m, 13 s",
+  "git_hash" : "cb6813f044607bc01895296223a27e4466ab0913",
+  "compile_time" : "Fri Sep 2 08:19:12 UTC 2016",
+  "compiled_by" : "root",
+  "compiled_in" : "ba19f7d3be65"
+}
+}
+[]
 ```
 
 Thanks to the docker swarm internal routing mesh, you can actually perform
@@ -151,30 +143,30 @@ where the request on port `1026` can be attended (i.e, any node running Orion).
 Let's insert some data...
 
 ```
-    $ sh ../insert.sh $(docker-machine ip ms-worker1)
+$ sh ../insert.sh $(docker-machine ip ms-worker1)
 ```
 
 And check it's there...
 
 ```
-    $ sh ../query.sh $(docker-machine ip ms-worker0)
-    ...
-    [
-        {
-            "id": "Room1",
-            "pressure": {
-                "metadata": {},
-                "type": "Integer",
-                "value": 720
-            },
-            "temperature": {
-                "metadata": {},
-                "type": "Float",
-                "value": 23
-            },
-            "type": "Room"
-        }
-    ]
+$ sh ../query.sh $(docker-machine ip ms-worker0)
+...
+[
+    {
+        "id": "Room1",
+        "pressure": {
+            "metadata": {},
+            "type": "Integer",
+            "value": 720
+        },
+        "temperature": {
+            "metadata": {},
+            "type": "Float",
+            "value": 23
+        },
+        "type": "Room"
+    }
+]
 ```
 
 Yes, you can query any of the three nodes.
@@ -188,7 +180,7 @@ in the swarm.
 Scaling up and down orion is a simple as runnnig something like...
 
 ```
-    $ docker service scale orion_orion=2
+$ docker service scale orion_orion=2
 ```
 
 (this maps to the `replicas` argument in the docker-compose)
@@ -197,27 +189,27 @@ Consequently, one of the nodes (ms-worker1 in my case) is no longer running
 Orion...
 
 ```
-    $ docker service ps orion_orion
-    ID            NAME                    IMAGE               NODE         DESIRED STATE  CURRENT STATE           ERROR  PORTS
-    2tibpye24o5q  orion_orion.2  fiware/orion:1.3.0  ms-manager0  Running        Running 11 minutes ago         
-    w9zmn8pp61ql  orion_orion.3  fiware/orion:1.3.0  ms-worker0   Running        Running 11 minutes ago
+$ docker service ps orion_orion
+ID            NAME                    IMAGE               NODE         DESIRED STATE  CURRENT STATE           ERROR  PORTS
+2tibpye24o5q  orion_orion.2  fiware/orion:1.3.0  ms-manager0  Running        Running 11 minutes ago         
+w9zmn8pp61ql  orion_orion.3  fiware/orion:1.3.0  ms-worker0   Running        Running 11 minutes ago
 ```
 
 But still responds to the querying as mentioned above...
 
 ```
-    $ sh ../query.sh $(docker-machine ip ms-worker1)
-    {
-      "orion" : {
-      "version" : "1.3.0",
-      "uptime" : "0 d, 0 h, 14 m, 30 s",
-      "git_hash" : "cb6813f044607bc01895296223a27e4466ab0913",
-      "compile_time" : "Fri Sep 2 08:19:12 UTC 2016",
-      "compiled_by" : "root",
-      "compiled_in" : "ba19f7d3be65"
-    }
-    }
-    []
+$ sh ../query.sh $(docker-machine ip ms-worker1)
+{
+  "orion" : {
+  "version" : "1.3.0",
+  "uptime" : "0 d, 0 h, 14 m, 30 s",
+  "git_hash" : "cb6813f044607bc01895296223a27e4466ab0913",
+  "compile_time" : "Fri Sep 2 08:19:12 UTC 2016",
+  "compiled_by" : "root",
+  "compiled_in" : "ba19f7d3be65"
+}
+}
+[]
 ```
 
 You can see the [mongo replica recipe](../../../utils/mongo-replicaset) to see
@@ -234,46 +226,46 @@ goes down. Let's show this by running the following (always on the manager
 node):
 
 ```
-    $ docker ps
-    CONTAINER ID        IMAGE                                                                                                COMMAND                  CREATED             STATUS              PORTS               NAMES
-    abc5e37037f0        fiware/orion@sha256:734c034d078d22f4479e8d08f75b0486ad5a05bfb36b2a1f1ba90ecdba2040a9                 "/usr/bin/contextB..."   2 minutes ago       Up 2 minutes        1026/tcp            orion_orion.1.o9ebbardwvzn1gr11pmf61er8
-    1d79dca4ff28        martel/mongo-replica-ctrl@sha256:f53d1ebe53624dcf7220fe02b3d764f1b0a34f75cb9fff309574a8be0625553a   "python /src/repli..."   About an hour ago   Up About an hour                        mongo-rs_mongo-controller.1.xomw6zf1o0wq0wbut9t5jx99j
-    8ea3b24bee1c        mongo@sha256:0d4453308cc7f0fff863df2ecb7aae226ee7fe0c5257f857fd892edf6d2d9057                        "/usr/bin/mongod -..."   About an hour ago   Up About an hour    27017/tcp           mongo-rs_mongo.ta8olaeg1u1wobs3a2fprwhm6.3akgzz28zp81beovcqx182nkz
+$ docker ps
+CONTAINER ID        IMAGE                                                                                                COMMAND                  CREATED             STATUS              PORTS               NAMES
+abc5e37037f0        fiware/orion@sha256:734c034d078d22f4479e8d08f75b0486ad5a05bfb36b2a1f1ba90ecdba2040a9                 "/usr/bin/contextB..."   2 minutes ago       Up 2 minutes        1026/tcp            orion_orion.1.o9ebbardwvzn1gr11pmf61er8
+1d79dca4ff28        martel/mongo-replica-ctrl@sha256:f53d1ebe53624dcf7220fe02b3d764f1b0a34f75cb9fff309574a8be0625553a   "python /src/repli..."   About an hour ago   Up About an hour                        mongo-rs_mongo-controller.1.xomw6zf1o0wq0wbut9t5jx99j
+8ea3b24bee1c        mongo@sha256:0d4453308cc7f0fff863df2ecb7aae226ee7fe0c5257f857fd892edf6d2d9057                        "/usr/bin/mongod -..."   About an hour ago   Up About an hour    27017/tcp           mongo-rs_mongo.ta8olaeg1u1wobs3a2fprwhm6.3akgzz28zp81beovcqx182nkz
 ```
 
 Suppose orion container goes down...
 
 ```
-    $ docker rm -f abc5e37037f0
+$ docker rm -f abc5e37037f0
 ```
 
 You will see it gone, but after a while it will automatically come back.
 
 ```
-    $ docker ps
-    CONTAINER ID        IMAGE                                                                                                COMMAND                  CREATED             STATUS              PORTS               NAMES
-    1d79dca4ff28        martel/mongo-replica-ctrl@sha256:f53d1ebe53624dcf7220fe02b3d764f1b0a34f75cb9fff309574a8be0625553a   "python /src/repli..."   About an hour ago   Up About an hour                        mongo-rs_mongo-controller.1.xomw6zf1o0wq0wbut9t5jx99j
-    8ea3b24bee1c        mongo@sha256:0d4453308cc7f0fff863df2ecb7aae226ee7fe0c5257f857fd892edf6d2d9057                        "/usr/bin/mongod -..."   About an hour ago   Up About an hour    27017/tcp           mongo-rs_mongo.ta8olaeg1u1wobs3a2fprwhm6.3akgzz28zp81beovcqx182nkz
+$ docker ps
+CONTAINER ID        IMAGE                                                                                                COMMAND                  CREATED             STATUS              PORTS               NAMES
+1d79dca4ff28        martel/mongo-replica-ctrl@sha256:f53d1ebe53624dcf7220fe02b3d764f1b0a34f75cb9fff309574a8be0625553a   "python /src/repli..."   About an hour ago   Up About an hour                        mongo-rs_mongo-controller.1.xomw6zf1o0wq0wbut9t5jx99j
+8ea3b24bee1c        mongo@sha256:0d4453308cc7f0fff863df2ecb7aae226ee7fe0c5257f857fd892edf6d2d9057                        "/usr/bin/mongod -..."   About an hour ago   Up About an hour    27017/tcp           mongo-rs_mongo.ta8olaeg1u1wobs3a2fprwhm6.3akgzz28zp81beovcqx182nkz
 
-    $ docker ps
-    CONTAINER ID        IMAGE                                                                                                COMMAND                  CREATED             STATUS                  PORTS               NAMES
-    60ba3f431d9d        fiware/orion@sha256:734c034d078d22f4479e8d08f75b0486ad5a05bfb36b2a1f1ba90ecdba2040a9                 "/usr/bin/contextB..."   6 seconds ago       Up Less than a second   1026/tcp            orion_orion.1.uj1gghehb2s1gnoestup2ugs5
-    1d79dca4ff28        martel/mongo-replica-ctrl@sha256:f53d1ebe53624dcf7220fe02b3d764f1b0a34f75cb9fff309574a8be0625553a   "python /src/repli..."   About an hour ago   Up About an hour                            mongo-rs_mongo-controller.1.xomw6zf1o0wq0wbut9t5jx99j
-    8ea3b24bee1c        mongo@sha256:0d4453308cc7f0fff863df2ecb7aae226ee7fe0c5257f857fd892edf6d2d9057                        "/usr/bin/mongod -..."   About an hour ago   Up About an hour        27017/tcp           mongo-rs_mongo.ta8olaeg1u1wobs3a2fprwhm6.3akgzz28zp81beovcqx182nkz
+$ docker ps
+CONTAINER ID        IMAGE                                                                                                COMMAND                  CREATED             STATUS                  PORTS               NAMES
+60ba3f431d9d        fiware/orion@sha256:734c034d078d22f4479e8d08f75b0486ad5a05bfb36b2a1f1ba90ecdba2040a9                 "/usr/bin/contextB..."   6 seconds ago       Up Less than a second   1026/tcp            orion_orion.1.uj1gghehb2s1gnoestup2ugs5
+1d79dca4ff28        martel/mongo-replica-ctrl@sha256:f53d1ebe53624dcf7220fe02b3d764f1b0a34f75cb9fff309574a8be0625553a   "python /src/repli..."   About an hour ago   Up About an hour                            mongo-rs_mongo-controller.1.xomw6zf1o0wq0wbut9t5jx99j
+8ea3b24bee1c        mongo@sha256:0d4453308cc7f0fff863df2ecb7aae226ee7fe0c5257f857fd892edf6d2d9057                        "/usr/bin/mongod -..."   About an hour ago   Up About an hour        27017/tcp           mongo-rs_mongo.ta8olaeg1u1wobs3a2fprwhm6.3akgzz28zp81beovcqx182nkz
 ```
 
 Even if a whole node goes down, the service will remain working because you had
 both redundant orion instances and redundant db replicas.
 
 ```
-    $ docker-machine rm ms-worker0
+$ docker-machine rm ms-worker0
 ```
 
 You will still get replies to...
 
 ```
-    $ sh ../query.sh $(docker-machine ip ms-manager0)
-    $ sh ../query.sh $(docker-machine ip ms-worker1)
+$ sh ../query.sh $(docker-machine ip ms-manager0)
+$ sh ../query.sh $(docker-machine ip ms-worker1)
 ```
 
 ## Networks considerations

--- a/recipes/data-management/context-broker/ha/settings.bat
+++ b/recipes/data-management/context-broker/ha/settings.bat
@@ -1,0 +1,8 @@
+@ECHO OFF
+
+:: Mongo
+setx MONGO_SERVICE_URI mongo
+
+:: Orion
+setx ORION_VERSION 1.12.0
+setx ORION_LOG_LEVEL DEBUG

--- a/recipes/data-management/context-broker/ha/settings.env
+++ b/recipes/data-management/context-broker/ha/settings.env
@@ -1,0 +1,9 @@
+# Env variables to customize the recipe.
+
+# Mongo
+export REPLICASET_NAME=${REPLICASET_NAME:-"rs"}
+export MONGO_SERVICE_URI=mongo
+
+# Orion
+export ORION_VERSION=1.12.0
+export ORION_LOG_LEVEL=DEBUG

--- a/recipes/data-management/quantumleap/docker-compose.yml
+++ b/recipes/data-management/quantumleap/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - frontend
 
   traefik:
-    image: traefik:1.3.5-alpine
+    image: traefik:${TRAEFIK_VERSION:-1.3.5-alpine}
     command:
       - --web
       - --docker
@@ -62,7 +62,7 @@ services:
           memory: 36M
 
   crate:
-    image: crate:1.0.5
+    image: crate:${CRATE_VERSION:-2.3.6}
     # ports:
       # Admin UI
     #   - 4200:4200

--- a/recipes/data-management/quantumleap/readme.md
+++ b/recipes/data-management/quantumleap/readme.md
@@ -88,7 +88,8 @@ proxy.
 You will also need to set the values for the following 3 special environment
 variables, depending on the structure of your cluster. The default values will
 assume your cluster has only 1 node, which is not ideal if your cluster has
-multiple nodes. Make sure you have the correct values in `settings.env` (or `settings.bat` in Windows)
+multiple nodes. Make sure you have the correct values in `settings.env`
+(or `settings.bat` in Windows)
 
 - `EXPECTED_NODES`: How many nodes to wait for until the cluster state is
   recovered. The value should be equal to the number of nodes in the cluster.

--- a/recipes/data-management/quantumleap/readme.md
+++ b/recipes/data-management/quantumleap/readme.md
@@ -67,18 +67,18 @@ Before we launch the stack, you need to define a domain for the entrypoint
 of your docker cluster. Save that domain in an environment variable like this:
 
 ```
-    $ export CLUSTER_DOMAIN=mydomain.com
+$ export CLUSTER_DOMAIN=mydomain.com
 ```
 
 If you are just testing locally and don't own one, you can fake it editing your
 `/etc/hosts` file to add an entry that points to the IP of any of the nodes of
-your Swarm Cluster (replace 192.168.99.100 with the IP if your cluster
+your Swarm Cluster (replace `192.168.99.100` with the IP if your cluster
 entrypoint). See the example below.
 
 ```
-    # End of /etc/hosts file
-    192.168.99.100  mydomain.com
-    192.168.99.100  crate.mydomain.com
+# End of /etc/hosts file
+192.168.99.100  mydomain.com
+192.168.99.100  crate.mydomain.com
 ```
 
 Note we've included one entry for `crate.mydomain.com` because we'll be
@@ -88,7 +88,7 @@ proxy.
 You will also need to set the values for the following 3 special environment
 variables, depending on the structure of your cluster. The default values will
 assume your cluster has only 1 node, which is not ideal if your cluster has
-multiple nodes.
+multiple nodes. Make sure you have the correct values in `settings.env` (or `settings.bat` in Windows)
 
 - `EXPECTED_NODES`: How many nodes to wait for until the cluster state is
   recovered. The value should be equal to the number of nodes in the cluster.
@@ -118,7 +118,8 @@ Now, we're ready to launch the stack with the name `ql`.
 If you want to deploy the basic stack of QuantumLeap you can simply run...
 
 ```
-    $ docker stack deploy -c docker-compose ql
+$ source settings.env  # In Windows, execute settings.bat instead.
+$ docker stack deploy -c docker-compose ql
 ```
 
 Otherwise, if you'd like to include some extra services such as Grafana for data
@@ -129,22 +130,22 @@ supporting
 Hence the suggested way to proceed is the following...
 
 ```
-    # First we merge the two compose files using docker-compose
-    $ docker-compose -f docker-compose.yml -f docker-compose-addons.yml config > ql.yml
-    # Now we deploy the "ql" stack from the generated ql.yml file.
-    $ docker stack deploy -c ql.yml ql
+# First we merge the two compose files using docker-compose
+$ docker-compose -f docker-compose.yml -f docker-compose-addons.yml config > ql.yml
+# Now we deploy the "ql" stack from the generated ql.yml file.
+$ docker stack deploy -c ql.yml ql
 ```
 
 Wait until you see all instances up and running (this might take some minutes).
 
 ```
-    $ docker service ls
-    ID                  NAME                MODE                REPLICAS            IMAGE                             PORTS
-    2vbj18blsqje        ql_traefik          global              1/1                 traefik:1.3.5-alpine              *:80->80/tcp,*:443->443/tcp,*:4200->4200/tcp,*:4300->4300/tcp,*:8080->8080/tcp
-    bvs32e81jcns        ql_viz              replicated          1/1                 dockersamples/visualizer:latest   *:8282->8080/tcp
-    e8kyp4vylvev        ql_quantumleap      replicated          1/1                 smartsdk/quantumleap:latest       *:8668->8668/tcp
-    ignls7l57hzn        ql_crate            global              3/3                 crate:1.0.5                       
-    tfszxc2fcmxx        ql_grafana          replicated          1/1                 grafana/grafana:latest            *:3000->3000/tcp
+$ docker service ls
+ID                  NAME                MODE                REPLICAS            IMAGE                             PORTS
+2vbj18blsqje        ql_traefik          global              1/1                 traefik:1.3.5-alpine              *:80->80/tcp,*:443->443/tcp,*:4200->4200/tcp,*:4300->4300/tcp,*:8080->8080/tcp
+bvs32e81jcns        ql_viz              replicated          1/1                 dockersamples/visualizer:latest   *:8282->8080/tcp
+e8kyp4vylvev        ql_quantumleap      replicated          1/1                 smartsdk/quantumleap:latest       *:8668->8668/tcp
+ignls7l57hzn        ql_crate            global              3/3                 crate:1.0.5                       
+tfszxc2fcmxx        ql_grafana          replicated          1/1                 grafana/grafana:latest            *:3000->3000/tcp
 ```
 
 Now you are ready to scale services according to your needs using simple docker
@@ -161,7 +162,7 @@ you have in the swarm cluster.
 For a quick test, you can use the `insert.sh` script in this folder.
 
 ```
-    $ sh insert.sh IP_OF_ANY_SWARM_NODE 8668
+$ sh insert.sh IP_OF_ANY_SWARM_NODE 8668
 ```
 
 Otherwise, open your favourite API tester and send the fake notification shown
@@ -169,34 +170,34 @@ below to QuantumLeap to later see it persisted in the database through the Crate
 Dashboard.
 
 ```
-    # Simple examples payload to send to IP_OF_ANY_SWARM_NODE:8668/notify
-    {
-        "subscriptionId": "5947d174793fe6f7eb5e3961",
-        "data": [
-            {
-                "id": "Room1",
-                "type": "Room",
-                "temperature": {
-                    "type": "Number",
-                    "value": 27.6,
-                    "metadata": {
-                        "dateModified": {
-                            "type": "DateTime",
-                            "value": "2017-06-19T11:46:45.00Z"
-                        }
+# Simple examples payload to send to IP_OF_ANY_SWARM_NODE:8668/notify
+{
+    "subscriptionId": "5947d174793fe6f7eb5e3961",
+    "data": [
+        {
+            "id": "Room1",
+            "type": "Room",
+            "temperature": {
+                "type": "Number",
+                "value": 27.6,
+                "metadata": {
+                    "dateModified": {
+                        "type": "DateTime",
+                        "value": "2017-06-19T11:46:45.00Z"
                     }
                 }
             }
-        ]
-    }
+        }
+    ]
+}
 ```
 
-Remember in the typical scenario is not the client that will be sending payloads
-directly to the `/notify` endpoint, but rather *Orion Context Broker* in the
-form of notifications. More info in the
+Remember in the typical scenario, it is not the client that will be sending
+payloads directly to the `/notify` endpoint, but rather *Orion Context Broker*
+in the form of notifications. More info in the
 [official documentation](https://smartsdk.github.io/ngsi-timeseries-api/).
 
-You can use the postman collection available in the
+For all these queries, you can use the postman collection available in the
 [tools section](../../tools/readme.md).
 
 For further information, please refer to the

--- a/recipes/data-management/quantumleap/settings.bat
+++ b/recipes/data-management/quantumleap/settings.bat
@@ -1,0 +1,15 @@
+@ECHO OFF
+
+:: Crate
+setx CRATE_VERSION "2.3.6"
+setx EXPECTED_NODES "1"
+setx RECOVER_AFTER_NODES "1"
+setx MINIMUM_MASTER_NODES "1"
+setx CLUSTER_DOMAIN "mydomain.com"
+
+:: Traefik
+setx TRAEFIK_VERSION "1.3.5-alpine"
+
+:: QL
+setx CRATE_HOST "crate"
+setx QL_VERSION "latest"

--- a/recipes/data-management/quantumleap/settings.env
+++ b/recipes/data-management/quantumleap/settings.env
@@ -1,0 +1,15 @@
+# Env variables to customize the recipe.
+
+# Crate
+export CRATE_VERSION="2.3.6"
+export EXPECTED_NODES=1
+export RECOVER_AFTER_NODES=1
+export MINIMUM_MASTER_NODES=1
+export CLUSTER_DOMAIN=mydomain.com
+
+# Traefik
+export TRAEFIK_VERSION="1.3.5-alpine"
+
+# QL
+export CRATE_HOST=crate
+export QL_VERSION=latest

--- a/recipes/tools/build.sh
+++ b/recipes/tools/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This command could be executed as a pre-commit hook.
+# We will keep even the generated files commited so that the user experience is
+# simplified. No problem with duplicated files as long as they're autogenenated.
+
+# Fetch external files
+## Utils
+curl -o ../utils/mongo-replicaset/docker-compose.yml -O https://raw.githubusercontent.com/smartsdk/mongo-rs-controller-swarm/master/docker-compose.yml
+curl -o ../utils/mongo-replicaset/mongo-healthcheck -O https://raw.githubusercontent.com/smartsdk/mongo-rs-controller-swarm/master/mongo-healthcheck
+
+# Generate Mastermind Files
+# ...
+
+# Generate Portainer Templates
+# ...

--- a/recipes/tools/postman_collection.json
+++ b/recipes/tools/postman_collection.json
@@ -1,8 +1,7 @@
 {
 	"info": {
-		"name": "SmartSDK",
 		"_postman_id": "4df65e23-cd35-4df2-db44-7bd0df8f9744",
-		"description": "",
+		"name": "SmartSDK",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -21,11 +20,13 @@
 							},
 							{
 								"key": "fiware-service",
-								"value": "default"
+								"value": "default",
+								"disabled": true
 							},
 							{
 								"key": "fiware-ServicePath",
-								"value": "/"
+								"value": "/",
+								"disabled": true
 							}
 						],
 						"body": {},
@@ -54,11 +55,13 @@
 							},
 							{
 								"key": "fiware-service",
-								"value": "default"
+								"value": "default",
+								"disabled": true
 							},
 							{
 								"key": "fiware-ServicePath",
-								"value": "/"
+								"value": "/",
+								"disabled": true
 							}
 						],
 						"body": {},
@@ -92,16 +95,18 @@
 							},
 							{
 								"key": "fiware-service",
-								"value": "default"
+								"value": "default",
+								"disabled": true
 							},
 							{
 								"key": "fiware-ServicePath",
-								"value": "/"
+								"value": "/",
+								"disabled": true
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"id\": \"Room1\",\n  \"type\": \"Room\",\n  \"temperature\": {\n    \"value\": 23,\n    \"type\": \"Float\"\n  },\n  \"pressure\": {\n    \"value\": 720,\n    \"type\": \"Integer\"\n  }\n}"
+							"raw": "{\n  \"id\": \"Room1\",\n  \"type\": \"Room\",\n  \"temperature\": {\n    \"value\": 24,\n    \"type\": \"Float\"\n  },\n  \"pressure\": {\n    \"value\": 721,\n    \"type\": \"Integer\"\n  }\n}"
 						},
 						"url": {
 							"raw": "http://{{ORION_EP}}/v2/entities",
@@ -133,16 +138,18 @@
 							},
 							{
 								"key": "fiware-service",
-								"value": "default"
+								"value": "default",
+								"disabled": true
 							},
 							{
 								"key": "fiware-ServicePath",
-								"value": "/"
+								"value": "/",
+								"disabled": true
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"temperature\": {\n    \"value\": 24,\n    \"type\": \"Number\"\n  },\n  \"pressure\": {\n    \"value\": 720,\n    \"type\": \"Integer\"\n  }\n}"
+							"raw": "{\n  \"temperature\": {\n    \"value\": 13,\n    \"type\": \"Number\"\n  },\n  \"pressure\": {\n    \"value\": 710,\n    \"type\": \"Integer\"\n  }\n}"
 						},
 						"url": {
 							"raw": "http://{{ORION_EP}}/v2/entities/Room1/attrs",
@@ -172,16 +179,18 @@
 							},
 							{
 								"key": "fiware-service",
-								"value": "default"
+								"value": "default",
+								"disabled": true
 							},
 							{
 								"key": "fiware-ServicePath",
-								"value": "/"
+								"value": "/",
+								"disabled": true
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "http://{{ORION_EP}}/v2/entities/Room1",
+							"raw": "http://{{ORION_EP}}/v2/entities/?type=Room",
 							"protocol": "http",
 							"host": [
 								"{{ORION_EP}}"
@@ -189,10 +198,15 @@
 							"path": [
 								"v2",
 								"entities",
-								"Room1"
+								""
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": "Room"
+								}
 							]
-						},
-						"description": ""
+						}
 					},
 					"response": []
 				},
@@ -207,11 +221,13 @@
 							},
 							{
 								"key": "fiware-service",
-								"value": "default"
+								"value": "default",
+								"disabled": true
 							},
 							{
 								"key": "fiware-ServicePath",
-								"value": "/"
+								"value": "/#",
+								"disabled": true
 							}
 						],
 						"body": {},
@@ -232,9 +248,9 @@
 					"response": []
 				},
 				{
-					"name": "Orion subscription",
+					"name": "Orion subscription v1",
 					"request": {
-						"method": "PUT",
+						"method": "POST",
 						"header": [
 							{
 								"key": "Accept",
@@ -255,7 +271,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"entities\": [\n        {\n            \"type\": \"Room\",\n            \"id\": \"Room1\"\n        }\n    ],\n    \"attributes\": [\n        \"temperature\",\n        \"pressure\"\n    ],\n    \"reference\": \"http://comet:8666/notify\",\n    \"notifyConditions\": [\n        {\n            \"type\": \"ONCHANGE\",\n            \"condValues\": [\n                \"temperature\",\n                \"pressure\"\n            ]\n        }\n    ]\n}"
+							"raw": "{\n    \"entities\": [\n        {\n            \"type\": \"TrafficFlowObserved\",\n            \"id\": \".*\",\n            \"isPattern\": \"true\"\n        }\n    ],\n    \"attributes\": [\n    ],\n    \"reference\": \"http://comet:8666/notify\",\n    \"duration\": \"P1Y\",\n    \"notifyConditions\": [\n        {\n            \"type\": \"ONCHANGE\",\n            \"condValues\": [\n            ]\n        }\n    ]\n}"
 						},
 						"url": {
 							"raw": "http://{{ORION_EP}}/v1/subscribeContext",
@@ -273,9 +289,86 @@
 					"response": []
 				},
 				{
+					"name": "Orion subscription v2",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "fiware-service",
+								"value": "default"
+							},
+							{
+								"key": "fiware-ServicePath",
+								"value": "/"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"description\": \"device\",\n    \"notification\": {\n        \"attrs\": [],\n        \"http\": {\n            \"url\": \"http://quantumleap:8668/v2/notify\"\n        },\n        \"metadata\": [\n            \"dateCreated\",\n            \"dateModified\"\n        ]\n    },\n    \"subject\": {\n        \"condition\": {\n            \"attrs\": []\n        },\n        \"entities\": [\n            {\n                \"idPattern\": \".*\",\n                \"type\": \"Device\"\n            }\n        ]\n    }\n}"
+						},
+						"url": {
+							"raw": "http://{{ORION_EP}}/v2/subscriptions",
+							"protocol": "http",
+							"host": [
+								"{{ORION_EP}}"
+							],
+							"path": [
+								"v2",
+								"subscriptions"
+							]
+						},
+						"description": "Subscribe Comet to Orion changes in Swarm"
+					},
+					"response": []
+				},
+				{
 					"name": "Orion subscription",
 					"request": {
 						"method": "DELETE",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							},
+							{
+								"key": "fiware-service",
+								"value": "default",
+								"disabled": true
+							},
+							{
+								"key": "fiware-ServicePath",
+								"value": "/",
+								"disabled": true
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://{{ORION_EP}}/v2/subscriptions/5ae2faa8cfdf0100fa49eb1f",
+							"protocol": "http",
+							"host": [
+								"{{ORION_EP}}"
+							],
+							"path": [
+								"v2",
+								"subscriptions",
+								"5ae2faa8cfdf0100fa49eb1f"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Orion subscription",
+					"request": {
+						"method": "PATCH",
 						"header": [
 							{
 								"key": "Accept",
@@ -290,9 +383,12 @@
 								"value": "/"
 							}
 						],
-						"body": {},
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"subject\": {\n        \"entities\": [\n            {\n                \"idPattern\": \".*\",\n                \"type\": \"TrafficFlowObserved\"\n            }\n        ],\n        \"condition\": {\n            \"attrs\": []\n        }\n    }\n}"
+						},
 						"url": {
-							"raw": "http://{{ORION_EP}}/v2/subscriptions/5a0dbfdd30073de858882d0f",
+							"raw": "http://{{ORION_EP}}/v2/subscriptions/5a9ffeea40ec920fbdffb0e6",
 							"protocol": "http",
 							"host": [
 								"{{ORION_EP}}"
@@ -300,10 +396,9 @@
 							"path": [
 								"v2",
 								"subscriptions",
-								"5a0dbfdd30073de858882d0f"
+								"5a9ffeea40ec920fbdffb0e6"
 							]
-						},
-						"description": ""
+						}
 					},
 					"response": []
 				}
@@ -407,7 +502,7 @@
 						],
 						"body": {},
 						"url": {
-							"raw": "http://{{COMET_EP}}/STH/v1/contextEntities/type/Room/id/Room1/attributes/pressure?lastN=10&hLimit=100",
+							"raw": "http://{{COMET_EP}}/STH/v1/contextEntities/type/TrafficFlowObserved/id/traffic_flow_observer_0/attributes/intensity?lastN=10&hLimit=10",
 							"protocol": "http",
 							"host": [
 								"{{COMET_EP}}"
@@ -417,28 +512,132 @@
 								"v1",
 								"contextEntities",
 								"type",
-								"Room",
+								"TrafficFlowObserved",
 								"id",
-								"Room1",
+								"traffic_flow_observer_0",
 								"attributes",
-								"pressure"
+								"intensity"
 							],
 							"query": [
 								{
 									"key": "lastN",
-									"value": "10",
-									"equals": true
+									"value": "10"
 								},
 								{
 									"key": "hLimit",
-									"value": "100",
-									"equals": true
+									"value": "10"
 								}
 							]
 						},
 						"description": "Historical data in Swarm"
 					},
-					"response": []
+					"response": [
+						{
+							"id": "966ffcf9-1ddc-48c1-b179-fc83b8e0ac14",
+							"name": "Comet raw information",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									},
+									{
+										"key": "fiware-service",
+										"value": "default"
+									},
+									{
+										"key": "fiware-ServicePath",
+										"value": "/"
+									}
+								],
+								"body": {},
+								"url": {
+									"raw": "http://{{COMET_EP}}/STH/v1/contextEntities/type/TrafficFlowObserved/id/traffic_flow_observer_0/attributes/intensity?lastN=10&hLimit=10",
+									"protocol": "http",
+									"host": [
+										"{{COMET_EP}}"
+									],
+									"path": [
+										"STH",
+										"v1",
+										"contextEntities",
+										"type",
+										"TrafficFlowObserved",
+										"id",
+										"traffic_flow_observer_0",
+										"attributes",
+										"intensity"
+									],
+									"query": [
+										{
+											"key": "lastN",
+											"value": "10"
+										},
+										{
+											"key": "hLimit",
+											"value": "10"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Connection",
+									"value": "keep-alive",
+									"name": "Connection",
+									"description": "Options that are desired for the connection"
+								},
+								{
+									"key": "Date",
+									"value": "Tue, 28 Nov 2017 12:05:34 GMT",
+									"name": "Date",
+									"description": "The date and time that the message was sent"
+								},
+								{
+									"key": "Transfer-Encoding",
+									"value": "chunked",
+									"name": "Transfer-Encoding",
+									"description": "The form of encoding used to safely transfer the entity to the user. Currently defined methods are: chunked, compress, deflate, gzip, identity."
+								},
+								{
+									"key": "cache-control",
+									"value": "no-cache",
+									"name": "cache-control",
+									"description": "Tells all caching mechanisms from server to client whether they may cache this object. It is measured in seconds"
+								},
+								{
+									"key": "content-encoding",
+									"value": "gzip",
+									"name": "content-encoding",
+									"description": "The type of encoding used on the data."
+								},
+								{
+									"key": "content-type",
+									"value": "application/json; charset=utf-8",
+									"name": "content-type",
+									"description": "The mime type of this content"
+								},
+								{
+									"key": "fiware-correlator",
+									"value": "fa01e0e2-f6de-4dfd-96b5-2c6c43b40c6c",
+									"name": "fiware-correlator",
+									"description": "Custom header"
+								},
+								{
+									"key": "vary",
+									"value": "accept-encoding",
+									"name": "vary",
+									"description": "Tells downstream proxies how to match future request headers to decide whether the cached response can be used rather than requesting a fresh one from the origin server."
+								}
+							],
+							"cookie": [],
+							"body": "{\"contextResponses\":[{\"contextElement\":{\"attributes\":[{\"name\":\"intensity\",\"values\":[{\"recvTime\":\"2017-11-24T09:30:17.797Z\",\"attrType\":\"Number\",\"attrValue\":0},{\"recvTime\":\"2017-11-24T09:30:26.859Z\",\"attrType\":\"Number\",\"attrValue\":1},{\"recvTime\":\"2017-11-24T09:30:35.915Z\",\"attrType\":\"Number\",\"attrValue\":1},{\"recvTime\":\"2017-11-24T09:30:44.974Z\",\"attrType\":\"Number\",\"attrValue\":3},{\"recvTime\":\"2017-11-24T09:30:54.051Z\",\"attrType\":\"Number\",\"attrValue\":0},{\"recvTime\":\"2017-11-24T09:31:03.140Z\",\"attrType\":\"Number\",\"attrValue\":1},{\"recvTime\":\"2017-11-24T09:31:12.209Z\",\"attrType\":\"Number\",\"attrValue\":3},{\"recvTime\":\"2017-11-24T09:31:21.290Z\",\"attrType\":\"Number\",\"attrValue\":3},{\"recvTime\":\"2017-11-24T09:31:30.342Z\",\"attrType\":\"Number\",\"attrValue\":1},{\"recvTime\":\"2017-11-24T17:03:30.560Z\",\"attrType\":\"Number\",\"attrValue\":9}]}],\"id\":\"traffic_flow_observer_0\",\"isPattern\":false,\"type\":\"TrafficFlowObserved\"},\"statusCode\":{\"code\":\"200\",\"reasonPhrase\":\"OK\"}}]}"
+						}
+					]
 				},
 				{
 					"name": "Comet aggregated information",
@@ -460,7 +659,7 @@
 						],
 						"body": {},
 						"url": {
-							"raw": "http://{{COMET_EP}}/STH/v1/contextEntities/type/Room/id/Room1/attributes/pressure?aggrMethod=max&aggrPeriod=second&lastN=10&hLimit=100",
+							"raw": "http://{{COMET_EP}}/STH/v1/contextEntities/type/TrafficFlowObserved/id/traffic_flow_observer_0/attributes/intensity?aggrMethod=max&aggrPeriod=hour&hLimit=10",
 							"protocol": "http",
 							"host": [
 								"{{COMET_EP}}"
@@ -470,32 +669,24 @@
 								"v1",
 								"contextEntities",
 								"type",
-								"Room",
+								"TrafficFlowObserved",
 								"id",
-								"Room1",
+								"traffic_flow_observer_0",
 								"attributes",
-								"pressure"
+								"intensity"
 							],
 							"query": [
 								{
 									"key": "aggrMethod",
-									"value": "max",
-									"equals": true
+									"value": "max"
 								},
 								{
 									"key": "aggrPeriod",
-									"value": "second",
-									"equals": true
-								},
-								{
-									"key": "lastN",
-									"value": "10",
-									"equals": true
+									"value": "hour"
 								},
 								{
 									"key": "hLimit",
-									"value": "100",
-									"equals": true
+									"value": "10"
 								}
 							]
 						},
@@ -520,21 +711,24 @@
 							},
 							{
 								"key": "fiware-service",
-								"value": "default"
+								"value": "default",
+								"disabled": true
 							},
 							{
 								"key": "fiware-ServicePath",
-								"value": "/"
+								"value": "/",
+								"disabled": true
 							}
 						],
 						"body": {},
 						"url": {
-							"raw": "http://{{QL_EP}}/version",
+							"raw": "http://{{QL_EP}}/v2/version",
 							"protocol": "http",
 							"host": [
 								"{{QL_EP}}"
 							],
 							"path": [
+								"v2",
 								"version"
 							]
 						},
@@ -553,30 +747,53 @@
 							},
 							{
 								"key": "fiware-service",
-								"value": "default"
+								"value": "default",
+								"disabled": true
 							},
 							{
 								"key": "fiware-ServicePath",
-								"value": "/"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json"
+								"value": "/",
+								"disabled": true
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"description\": \"QL Subscription\",\n    \"subject\": {\n        \"entities\": [\n        {\n            \"type\": \"Room\",\n            \"id\": \"Room1\"\n        }\n        ],\n        \"condition\": {\n            \"attrs\": [\n            \"temperature\",\n            \"pressure\"\n            ]\n        }\n    },\n    \"notification\": {\n        \"http\": {\n            \"url\": \"http://192.0.0.1:8668/notify\"\n        },\n        \"attrs\": [\n        \"temperature\",\n        \"pressure\"\n        ],\n        \"metadata\": [\"dateCreated\", \"dateModified\"]\n    },\n    \"throttling\": 5\n}"
+							"raw": ""
 						},
 						"url": {
-							"raw": "http://{{ORION_EP}}/v2/subscriptions",
+							"raw": "http://{{QL_EP}}/v2/subscribe?orionUrl=http://{{ORION_EP}}/v2&quantumleapUrl=http://quantumleap:8668/v2",
 							"protocol": "http",
 							"host": [
-								"{{ORION_EP}}"
+								"{{QL_EP}}"
 							],
 							"path": [
 								"v2",
-								"subscriptions"
+								"subscribe"
+							],
+							"query": [
+								{
+									"key": "orionUrl",
+									"value": "http://{{ORION_EP}}/v2"
+								},
+								{
+									"key": "quantumleapUrl",
+									"value": "http://quantumleap:8668/v2"
+								},
+								{
+									"key": "entityType",
+									"value": "AirQualityObserved",
+									"disabled": true
+								},
+								{
+									"key": "idPattern",
+									"value": null,
+									"disabled": true
+								},
+								{
+									"key": "attributes",
+									"value": null,
+									"disabled": true
+								}
 							]
 						},
 						"description": "Subscribe Comet to Orion changes in Swarm"
@@ -594,28 +811,164 @@
 							},
 							{
 								"key": "Fiware-Service",
-								"value": "default"
+								"value": "default",
+								"disabled": true
 							},
 							{
 								"key": "Fiware-ServicePath",
-								"value": "/"
+								"value": "/",
+								"disabled": true
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"subscriptionId\": \"5947d174793fe6f7eb5e3961\", \n\t\"data\": [\n\t\t{\n\t\t\t\"id\": \"Room1\", \n\t\t\t\"type\": \"Room\", \n\t\t\t\"temperature\": {\n\t\t\t\t\"type\": \"Number\", \n\t\t\t\t\"value\": 25.6, \n\t\t\t\t\"metadata\": {\n\t\t\t\t\t\"dateModified\": {\n\t\t\t\t\t\t\"type\": \"DateTime\", \n\t\t\t\t\t\t\"value\": \"2017-06-19T11:46:45.00Z\"\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t]\n}"
+							"raw": "{\n\t\"subscriptionId\": \"5947d174793fe6f7eb5e3961\", \n\t\"data\": [\n\t\t{\n        \"id\": \"299500\",\n        \"type\": \"AirQualityObserved\",\n        \"aqi\": {\"type\": \"string\", \"value\": \"5\", \"metadata\": {}},\n        \"city\": {\"type\": \"string\", \"value\": \"Charleroi\", \"metadata\": {}},\n        \"h\": {\"type\": \"string\", \"value\": \"87\", \"metadata\": {}},\n        \"location\": {\"type\": \"geo:point\", \"value\": \"50.4093114542045, 4.45217178148666\", \"metadata\": {}},\n        \"no2\": {\"type\": \"string\", \"value\": \"6.4\", \"metadata\": {}},\n        \"p\": {\"type\": \"string\", \"value\": \"994\", \"metadata\": {}},\n        \"pm10\": {\"type\": \"string\", \"value\": \"3\", \"metadata\": {}},\n        \"pm25\": {\"type\": \"string\", \"value\": \"5\", \"metadata\": {}},\n        \"t\": {\"type\": \"string\", \"value\": \"8.4\", \"metadata\": {}},\n        \"url\": {\"type\": \"string\", \"value\": \"https://orion.s.orchestracities.com/v2/entities/Charleroi\", \"metadata\": {}}\n    \t}\n\t]\n}"
 						},
 						"url": {
-							"raw": "http://{{QL_EP}}/notify",
+							"raw": "http://{{QL_EP}}/v2/notify",
 							"protocol": "http",
 							"host": [
 								"{{QL_EP}}"
 							],
 							"path": [
+								"v2",
 								"notify"
 							]
 						},
 						"description": "Insert entities into QL"
+					},
+					"response": []
+				},
+				{
+					"name": "QL query 1T1E1A",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://{{QL_EP}}/v2/entities/airqualityobserved_0/attrs/precipitation?type=AirQualityObserved",
+							"protocol": "http",
+							"host": [
+								"{{QL_EP}}"
+							],
+							"path": [
+								"v2",
+								"entities",
+								"airqualityobserved_0",
+								"attrs",
+								"precipitation"
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": "AirQualityObserved",
+									"description": "COMPULSORY FOR NOW"
+								},
+								{
+									"key": "fromDate",
+									"value": "2018-04-04T00:00:00",
+									"disabled": true
+								},
+								{
+									"key": "toDate",
+									"value": "2018-04-04T00:00:00",
+									"disabled": true
+								},
+								{
+									"key": "lastN",
+									"value": "4",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "2",
+									"disabled": true
+								},
+								{
+									"key": "offset",
+									"value": "1",
+									"disabled": true
+								},
+								{
+									"key": "aggrMethod",
+									"value": "max",
+									"disabled": true
+								}
+							]
+						},
+						"description": "Query historical values of 1 attribute of 1 entity of 1 type."
+					},
+					"response": []
+				},
+				{
+					"name": "QL query 1T1ENA",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Accept",
+								"value": "application/json"
+							}
+						],
+						"body": {},
+						"url": {
+							"raw": "http://{{QL_EP}}/v2/entities/airqualityobserved_0?type=AirQualityObserved&attrs=NO2,CO&lastN=4",
+							"protocol": "http",
+							"host": [
+								"{{QL_EP}}"
+							],
+							"path": [
+								"v2",
+								"entities",
+								"airqualityobserved_0"
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": "AirQualityObserved",
+									"description": "COMPULSORY FOR NOW"
+								},
+								{
+									"key": "attrs",
+									"value": "NO2,CO"
+								},
+								{
+									"key": "aggrMethod",
+									"value": "avg",
+									"disabled": true
+								},
+								{
+									"key": "fromDate",
+									"value": "2018-04-04T00:00:00",
+									"disabled": true
+								},
+								{
+									"key": "toDate",
+									"value": "2018-04-04T00:00:00",
+									"disabled": true
+								},
+								{
+									"key": "lastN",
+									"value": "4"
+								},
+								{
+									"key": "limit",
+									"value": "2",
+									"disabled": true
+								},
+								{
+									"key": "offset",
+									"value": "1",
+									"disabled": true
+								}
+							]
+						},
+						"description": "Query historical values of 1 attribute of 1 entity of 1 type."
 					},
 					"response": []
 				}

--- a/recipes/utils/mongo-replicaset/.gitignore
+++ b/recipes/utils/mongo-replicaset/.gitignore
@@ -1,2 +1,0 @@
-docker-compose.yml
-mongo-healthcheck

--- a/recipes/utils/mongo-replicaset/backend.env
+++ b/recipes/utils/mongo-replicaset/backend.env
@@ -1,5 +1,0 @@
-# Env variables to customize the recipe.
-STACK_NAME="mongo-rs"
-
-MONGO_VERSION=3.2
-REPLICASET_NAME=rs

--- a/recipes/utils/mongo-replicaset/docker-compose.yml
+++ b/recipes/utils/mongo-replicaset/docker-compose.yml
@@ -1,0 +1,70 @@
+version: '3.3'
+
+services:
+
+  mongo:
+    image: mongo:${MONGO_VERSION:-3.2}
+    # the bind_ip option is requried from MONGO Version 3.6, alternatively you can use --bind_ip_all
+    entrypoint: [ "/usr/bin/mongod", "--replSet", "${REPLICASET_NAME:-rs}", "--journal", "--smallfiles", "--bind_ip", "0.0.0.0"]
+    # ports:
+    #   - "${MONGO_PORT:-27017}:27017"
+    # The usage of volume provides persistence, but may work correctly only with 1 volume per node (that's why global mode is recommended)
+    volumes:
+      - mongodata:/data/db
+    networks:
+      - backend
+    configs:
+    # to avoid changes to the original mongo image, we import the healthcheck script using configs
+      - mongo-healthcheck
+    # it simply checks that the client can connect to mongo. No test is run w.r.t. the cluster.
+    healthcheck:
+        test: ["CMD", "bash", "/mongo-healthcheck"]
+        interval: 1m
+        timeout: 10s
+        retries: 3
+    deploy:
+      mode: global
+      restart_policy:
+        condition: on-failure
+      update_config:
+        parallelism: 1
+        delay: 1m30s
+
+  controller:
+    image: martel/mongo-replica-ctrl:latest
+    volumes:
+      # TODO: Avoid exposing the docker socket (security issue)
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - OVERLAY_NETWORK_NAME=${BACKEND_NETWORK_NAME:-backend}
+      - MONGO_SERVICE_NAME=${STACK_NAME:-mongo}_mongo
+      - REPLICASET_NAME=${REPLICASET_NAME:-rs}
+      - MONGO_PORT=27017
+          # - DEBUG=1 #uncomment to debug the script
+    entrypoint: python /src/replica_ctrl.py
+    networks:
+      - backend
+    depends_on:
+      - "mongo"
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints: [node.role==manager]
+      restart_policy:
+        condition: on-failure
+
+configs:
+  # to avoid changes to the original mongo image, we import the healthcheck script using configs
+  mongo-healthcheck:
+    file: mongo-healthcheck
+
+volumes:
+  # External true ensures that the volume is not re-created if already present
+  mongodata:
+    external: true
+
+networks:
+  backend:
+    external:
+      name: ${BACKEND_NETWORK_NAME:-backend}

--- a/recipes/utils/mongo-replicaset/mongo-healthcheck
+++ b/recipes/utils/mongo-replicaset/mongo-healthcheck
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eo pipefail
+
+host="$(hostname --ip-address || echo '127.0.0.1')"
+
+if mongo --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
+	exit 0
+fi
+
+exit 1

--- a/recipes/utils/mongo-replicaset/readme.md
+++ b/recipes/utils/mongo-replicaset/readme.md
@@ -58,7 +58,7 @@ Then, simply run from this same folder...
 
 ```
 $ source settings.env  # In Windows, simply execute settings.bat instead.
-$ docker stack deploy -c docker-compose.yml ${STACK_NAME:-"mongo-rs"}
+$ docker stack deploy -c docker-compose.yml mongo-rs
 ```
 
 Allow some time while images are pulled in the nodes and services are deployed.

--- a/recipes/utils/mongo-replicaset/readme.md
+++ b/recipes/utils/mongo-replicaset/readme.md
@@ -153,8 +153,7 @@ You can read more about this in
 [this Github issue](https://github.com/docker/docker/issues/26259).
 
 For further details, refer to the [mongo-rs-controller-swarm](https://github.com/smartsdk/mongo-rs-controller-swarm)
-repository, in particular the
-`[docker-compose.yml](https://github.com/smartsdk/mongo-rs-controller-swarm/blob/master/docker-compose.yml)`
+repository, in particular the [docker-compose.yml](https://github.com/smartsdk/mongo-rs-controller-swarm/blob/master/docker-compose.yml)
 file or the
-`[replica_ctrl.py](https://github.com/smartsdk/mongo-rs-controller-swarm/blob/master/src/replica_ctrl.py)`
+[replica_ctrl.py](https://github.com/smartsdk/mongo-rs-controller-swarm/blob/master/src/replica_ctrl.py)
 controller script.

--- a/recipes/utils/mongo-replicaset/settings.bat
+++ b/recipes/utils/mongo-replicaset/settings.bat
@@ -1,0 +1,4 @@
+@ECHO OFF
+setx STACK_NAME "mongo-rs"
+setx MONGO_VERSION "3.2"
+setx REPLICASET_NAME "rs"

--- a/recipes/utils/mongo-replicaset/settings.bat
+++ b/recipes/utils/mongo-replicaset/settings.bat
@@ -1,4 +1,3 @@
 @ECHO OFF
-setx STACK_NAME "mongo-rs"
 setx MONGO_VERSION "3.2"
 setx REPLICASET_NAME "rs"

--- a/recipes/utils/mongo-replicaset/settings.env
+++ b/recipes/utils/mongo-replicaset/settings.env
@@ -1,4 +1,3 @@
 # Env variables to customize the recipe.
-export STACK_NAME="mongo-rs"
 export MONGO_VERSION=3.2
 export REPLICASET_NAME=rs

--- a/recipes/utils/mongo-replicaset/settings.env
+++ b/recipes/utils/mongo-replicaset/settings.env
@@ -1,0 +1,4 @@
+# Env variables to customize the recipe.
+export STACK_NAME="mongo-rs"
+export MONGO_VERSION=3.2
+export REPLICASET_NAME=rs


### PR DESCRIPTION
Updating core recipes (mongo, orion, ql and iota) with checks from the guided-tour.

Removed bash-only script, preferring env var settings and plain docker stack deploy. This change is in the line of closer integration with generated files for portainer templates (and mastermind).